### PR TITLE
Fix deprecated things from dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,14 +143,14 @@ lda_model = gensim.models.ldamodel.LdaModel(corpus=corpus, id2word=id2word, num_
 
 
 @st.cache_data 
-def format_topics_sentences(ldamodel, corpus):
+def format_topics_sentences(_ldamodel, corpus):
     sent_topics_df = []
-    for i, row_list in enumerate(ldamodel[corpus]):
-        row = row_list[0] if ldamodel.per_word_topics else row_list
+    for i, row_list in enumerate(_ldamodel[corpus]):
+        row = row_list[0] if _ldamodel.per_word_topics else row_list
         row = sorted(row, key=lambda x: (x[1]), reverse=True)
         for j, (topic_num, prop_topic) in enumerate(row):
             if j == 0:
-                wp = ldamodel.show_topic(topic_num)
+                wp = _ldamodel.show_topic(topic_num)
                 topic_keywords = ", ".join([word for word, prop in wp])
                 sent_topics_df.append(
                     [i, int(topic_num), round(prop_topic, 4)*100, topic_keywords])
@@ -202,7 +202,7 @@ st.markdown("---")
 ####################### SETTING UP THE DATAFRAME FOR SUNBURST-GRAPH ############################
 
 df_topic_sents_keywords = format_topics_sentences(
-    ldamodel=lda_model, corpus=corpus)
+    _ldamodel=lda_model, corpus=corpus)
 df_some = pd.DataFrame(df_topic_sents_keywords, columns=[
                        'Document No', 'Dominant Topic', 'Topic % Contribution', 'Keywords'])
 df_some['Names'] = Resumes['Name']

--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ if option_yn == 'YES':
 
 
 #################################### SCORE CALCUATION ################################
-@st.cache()
+@st.cache_data
 def calculate_scores(resumes, job_description):
     scores = []
     for x in range(resumes.shape[0]):
@@ -119,7 +119,7 @@ st.markdown("---")
 ############################################ TF-IDF Code ###################################
 
 
-@st.cache()
+@st.cache_data
 def get_list_of_words(document):
     Document = []
 
@@ -142,7 +142,7 @@ lda_model = gensim.models.ldamodel.LdaModel(corpus=corpus, id2word=id2word, num_
 ################################### LDA CODE ##############################################
 
 
-@st.cache  # Trying to improve performance by reducing the rerun computations
+@st.cache_data 
 def format_topics_sentences(ldamodel, corpus):
     sent_topics_df = []
     for i, row_list in enumerate(ldamodel[corpus]):

--- a/tf_idf.py
+++ b/tf_idf.py
@@ -4,5 +4,5 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 def do_tfidf(token):
     tfidf = TfidfVectorizer(max_df=0.05, min_df=0.002)
     words = tfidf.fit_transform(token)
-    sentence = " ".join(tfidf.get_feature_names())
+    sentence = " ".join(tfidf.get_feature_names_out())
     return sentence


### PR DESCRIPTION
The fileReader.py wouldn't run, due to a deprecated attribute from SKLearn, used in the tf_idf.py file:
* Updating the deprecated attribute "get_feature_names" to the new "get_feature_names_out"

There was cache errors when running the app.py, as the old Streamlit st.cache was deprecated in favor of the two new commands st.cache_data and st.cache_resource as seen [here](https://blog.streamlit.io/introducing-two-new-caching-commands-to-replace-st-cache):
* updating the deprecated st.cache to the new st.cache_data

The new function st.cache_data doesn't support hashing at the moment, as mentioned [here](https://github.com/streamlit/streamlit/issues/5939) generating a UnhashableParamError.
* To address this, it was added an underscore to the ldamodel argument in the LDA CODE section, so streamlit wouldn' try to hash that argument.